### PR TITLE
Error - Cannot find module

### DIFF
--- a/packages/ui/public/images.d.ts
+++ b/packages/ui/public/images.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.svg';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src"],
+  "typeRoots": ["public/types"],
+  "include": ["src", "public/images.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- public : images/index.ts 에서 파일 타입을 찾지 못해서 발생

** 이미지 Module type 추가
1. packages/ui/tsconfig.json "typeRoots": ["public/types"], "include": ["src", "public/images.d.ts"],

2. add : public / images.d.ts declare module '*.png';
declare module '*.jpg';
declare module '*.jpeg';

-> 각 사용할 이미지의 타입 추가