### PR TITLE
[client] mbti 테스트 코맨트 추가/수정/삭제/작성취소 기능 구현

### DIFF
--- a/apps/client/app/GlobalStateRoot.jsx
+++ b/apps/client/app/GlobalStateRoot.jsx
@@ -19,7 +19,8 @@ export default function GlobalStateRoot({ children }) {
           prop !== 'imageUrl' &&
           prop !== 'zIndex' &&
           prop !== 'show' &&
-          prop !== 'logIn'
+          prop !== 'logIn' &&
+          prop !== 'borderBottom'
         }
       >
         {children}

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
 import { deleteComment, updateComment } from '@/services';
 import { doSetStateWithNewState, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
-import { validationBeforeWriteComment } from '@/utils/mbtiTest';
 
 import { CommentBodyWrap, CommentDetailWrap, CommentText, EachCommentWrap } from '@/components/base/styledComponents';
 import { Image } from '@/components/ui/CommonElements';
@@ -14,7 +12,6 @@ export default function CommentBody({ commentData, userInfo, setAction }: Base.C
   const [isModifying, setIsModifying] = useState(Array(commentData.length).fill(false));
   const [newValue, setNewValue] = useState('');
 
-  const router = useRouter();
   const role = decodeToken(userInfo[LOGIN.TOKEN_NAME])?.role;
   const memberId = userInfo[LOGIN.USER_MEMBER_ID];
   const isAdmin = role === LOGIN.ROLE_ADMIN;

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
+
 import { FONT, LOGIN } from '@/constants/constant';
-import { formatTimeDifference } from '@/utils/common';
+import { updateComment } from '@/services';
+import { formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
 
 import { CommentBodyWrap, CommentDetailWrap, CommentText, EachCommentWrap } from '@/components/base/styledComponents';
@@ -7,31 +10,57 @@ import { Image } from '@/components/ui/CommonElements';
 
 export default function CommentBody({
   commentData,
-  value,
   userInfo,
 }: {
   commentData: Model.CommentData[];
-  value: string;
   userInfo: Model.LogInState;
 }) {
+  const [isModifying, setIsModifying] = useState(Array(commentData.length).fill(false));
   const role = decodeToken(userInfo[LOGIN.TOKEN_NAME])?.role;
   const memberId = userInfo[LOGIN.USER_MEMBER_ID];
   const isAdmin = role === LOGIN.ROLE_ADMIN;
 
+  const handleClickCommentSubmitButton = (commentData: Model.CommentData) => {
+    const headers = getHeaders(true);
+    const body = {
+      id: commentData.id,
+      memberId: commentData.memberId,
+      testId: commentData.testId,
+      commentDate: new Date(),
+      content: 'new value',
+    };
+
+    updateComment(headers, body);
+  };
+
+  const handleClickCommentUpdateButton = (index: number) => {
+    const newArr = [...isModifying];
+    newArr[index] = true;
+
+    setIsModifying(newArr);
+  };
   return (
     <CommentBodyWrap>
-      {commentData.map((el: Model.CommentData) => (
+      {commentData.map((el: Model.CommentData, i: number) => (
         <EachCommentWrap key={el.id}>
           <Image src={el.thumbnailImage} width="2.5rem" height="2.5rem" borderRadius="1rem" />
           <CommentDetailWrap>
             <CommentText
               color={FONT.COLOR.DEEPGRAY}
             >{`${el.username} · ${formatTimeDifference(el.commentDate)}`}</CommentText>
-            <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>
+            {isModifying[i] ? <input type="text" /> : <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>}
           </CommentDetailWrap>
           <div>
-            {memberId === el.memberId && <p>수정</p>}
-            {isAdmin ? <p>삭제</p> : memberId === el.memberId && <p>삭제</p>}
+            {memberId === el.memberId && (
+              <p
+                onClick={() =>
+                  isModifying[i] ? handleClickCommentSubmitButton(el) : handleClickCommentUpdateButton(i)
+                }
+              >
+                {isModifying[i] ? '확인' : '수정'}
+              </p>
+            )}
+            {!isModifying[i] ? isAdmin ? <p>삭제</p> : memberId === el.memberId && <p>삭제</p> : <p>취소</p>}
           </div>
         </EachCommentWrap>
       ))}

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { FONT, KEY, LOGIN } from '@/constants/constant';
-import { getAllCommentData, updateComment } from '@/services';
+import { deleteComment, getAllCommentData, updateComment } from '@/services';
 import { doSetActionWithNewValue, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
 import { sortCommentByDate, validationBeforeWriteComment } from '@/utils/mbtiTest';
@@ -63,6 +63,21 @@ export default function CommentBody({
   const handleClickCommentUpdateButton = (index: number) =>
     doSetActionWithNewValue(isModifying, setIsModifying, index, true);
 
+  const handleClickCommentDeleteButton = async (commentData: Model.CommentData) => {
+    const confirmResult = confirm('삭제하시겠습니까?');
+    if (!confirmResult) return;
+
+    const headers = getHeaders(true);
+    const body = {
+      id: commentData.id,
+      memberId: commentData.memberId,
+    };
+    await deleteComment(headers, body);
+    await getAllCommentData(testId).then((response) => {
+      doSetActionWithNewValue(null, setComment, null, sortCommentByDate(response?.dataList));
+    });
+  };
+
   const handleClickCommentCancelButton = (index: number) =>
     doSetActionWithNewValue(isModifying, setIsModifying, index, false);
 
@@ -116,7 +131,11 @@ export default function CommentBody({
                   {textEditOrSubmit}
                 </p>
               )}
-              <p onClick={() => (isModifying[i] ? handleClickCommentCancelButton(i) : null)}>
+              <p
+                onClick={() =>
+                  isModifying[i] ? handleClickCommentCancelButton(i) : handleClickCommentDeleteButton(el)
+                }
+              >
                 {isEqualMemberId ? textDeleteOrCancel : isAdmin ? textDeleteOrCancel : null}
               </p>
             </div>

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,0 +1,23 @@
+import { FONT } from '@/constants/constant';
+import { formatTimeDifference } from '@/utils/common';
+
+import { CommentBodyWrap, CommentDetailWrap, CommentText, EachCommentWrap } from '@/components/base/styledComponents';
+import { Image } from '@/components/ui/CommonElements';
+
+export default function CommentBody({ commentData }: { commentData: Model.CommentData }) {
+  return (
+    <CommentBodyWrap>
+      {commentData.map((el: Base.MbtiTestCommentData) => (
+        <EachCommentWrap key={el.id}>
+          <Image src={el.thumbnailImage} width="2.5rem" height="2.5rem" borderRadius="1rem" />
+          <CommentDetailWrap>
+            <CommentText
+              color={FONT.COLOR.DEEPGRAY}
+            >{`${el.username} · ${formatTimeDifference(el.commentDate)}`}</CommentText>
+            <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>
+          </CommentDetailWrap>
+        </EachCommentWrap>
+      ))}
+    </CommentBodyWrap>
+  );
+}

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { FONT, KEY, LOGIN } from '@/constants/constant';
+import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
 import { deleteComment, getAllCommentData, updateComment } from '@/services';
 import { doSetActionWithNewValue, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
@@ -91,7 +91,13 @@ export default function CommentBody({
 
         return (
           <EachCommentWrap key={el.id}>
-            <Image src={el.thumbnailImage} width="2.5rem" height="2.5rem" borderRadius="1rem" />
+            <Image
+              src={el.thumbnailImage}
+              width="2.5rem"
+              height="2.5rem"
+              borderRadius="1rem"
+              alt={IMAGE_ALT_STRING.MONGBIT_TITLE + '코멘트 유저 이미지'}
+            />
             <CommentDetailWrap
               borderBottom={newValue.length >= 100 ? '1px solid red' : `1px solid ${FONT.COLOR.MEDIUMGRAY}`}
             >

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
 import { deleteComment, updateComment } from '@/services';
-import { doSetActionWithNewValue, formatTimeDifference, getHeaders } from '@/utils/common';
+import { doSetStateWithNewState, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
 import { validationBeforeWriteComment } from '@/utils/mbtiTest';
 
@@ -47,10 +47,10 @@ export default function CommentBody({ commentData, userInfo, setAction }: Base.C
     await updateComment(headers, body);
 
     setAction(`update ${new Date().toString()}`);
-    doSetActionWithNewValue(isModifying, setIsModifying, index, false);
+    doSetStateWithNewState(isModifying, setIsModifying, index, false);
   };
 
-  const handleClickCommentUpdate = (index: number) => doSetActionWithNewValue(isModifying, setIsModifying, index, true);
+  const handleClickCommentUpdate = (index: number) => doSetStateWithNewState(isModifying, setIsModifying, index, true);
 
   const handleClickCommentDelete = async (commentData: Model.CommentData) => {
     const confirmResult = confirm('삭제하시겠습니까?');
@@ -66,8 +66,7 @@ export default function CommentBody({ commentData, userInfo, setAction }: Base.C
     setAction(`delete ${new Date().toString()}`);
   };
 
-  const handleClickCommentCancel = (index: number) =>
-    doSetActionWithNewValue(isModifying, setIsModifying, index, false);
+  const handleClickCommentCancel = (index: number) => doSetStateWithNewState(isModifying, setIsModifying, index, false);
 
   return (
     <CommentBodyWrap>

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -32,9 +32,6 @@ export default function CommentBody({ commentData, userInfo, setAction }: Base.C
   const handleClickCommentSubmit = async (commentData: Model.CommentData, index: number) => {
     if (newValue === '') return;
 
-    const valiateState = validationBeforeWriteComment(userInfo, router);
-    if (!valiateState) return;
-
     const headers = getHeaders(true);
     const body = {
       id: commentData.id,

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
-import { FONT, LOGIN } from '@/constants/constant';
+import { FONT, KEY, LOGIN } from '@/constants/constant';
 import { getAllCommentData, updateComment } from '@/services';
 import { doSetActionWithNewValue, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
@@ -27,6 +27,14 @@ export default function CommentBody({
   const role = decodeToken(userInfo[LOGIN.TOKEN_NAME])?.role;
   const memberId = userInfo[LOGIN.USER_MEMBER_ID];
   const isAdmin = role === LOGIN.ROLE_ADMIN;
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    commentData: Model.CommentData,
+    index: number,
+  ) => {
+    if (event.key === KEY.ENTER && !event.nativeEvent.isComposing) handleClickCommentSubmitButton(commentData, index);
+  };
 
   const handleClickCommentSubmitButton = async (commentData: Model.CommentData, index: number) => {
     if (newValue === '') return;
@@ -84,6 +92,7 @@ export default function CommentBody({
                     type="text"
                     maxLength={100}
                     onChange={(event) => handleChangeInputValue(event)}
+                    onKeyDown={(event) => handleKeyDown(event, el, i)}
                   />
                   <div>
                     <p>{newValue.length}/</p>

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -1,13 +1,26 @@
-import { FONT } from '@/constants/constant';
+import { FONT, LOGIN } from '@/constants/constant';
 import { formatTimeDifference } from '@/utils/common';
+import { decodeToken } from '@/utils/logIn';
 
 import { CommentBodyWrap, CommentDetailWrap, CommentText, EachCommentWrap } from '@/components/base/styledComponents';
 import { Image } from '@/components/ui/CommonElements';
 
-export default function CommentBody({ commentData }: { commentData: Model.CommentData }) {
+export default function CommentBody({
+  commentData,
+  value,
+  userInfo,
+}: {
+  commentData: Model.CommentData[];
+  value: string;
+  userInfo: Model.LogInState;
+}) {
+  const role = decodeToken(userInfo[LOGIN.TOKEN_NAME])?.role;
+  const memberId = userInfo[LOGIN.USER_MEMBER_ID];
+  const isAdmin = role === LOGIN.ROLE_ADMIN;
+
   return (
     <CommentBodyWrap>
-      {commentData.map((el: Base.MbtiTestCommentData) => (
+      {commentData.map((el: Model.CommentData) => (
         <EachCommentWrap key={el.id}>
           <Image src={el.thumbnailImage} width="2.5rem" height="2.5rem" borderRadius="1rem" />
           <CommentDetailWrap>
@@ -16,6 +29,10 @@ export default function CommentBody({ commentData }: { commentData: Model.Commen
             >{`${el.username} · ${formatTimeDifference(el.commentDate)}`}</CommentText>
             <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>
           </CommentDetailWrap>
+          <div>
+            {memberId === el.memberId && <p>수정</p>}
+            {isAdmin ? <p>삭제</p> : memberId === el.memberId && <p>삭제</p>}
+          </div>
         </EachCommentWrap>
       ))}
     </CommentBodyWrap>

--- a/apps/client/components/base/CommentBody.tsx
+++ b/apps/client/components/base/CommentBody.tsx
@@ -2,15 +2,15 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
-import { deleteComment, getMbtiTestCommentData, updateComment } from '@/services';
+import { deleteComment, updateComment } from '@/services';
 import { doSetActionWithNewValue, formatTimeDifference, getHeaders } from '@/utils/common';
 import { decodeToken } from '@/utils/logIn';
-import { sortCommentByDate, validationBeforeWriteComment } from '@/utils/mbtiTest';
+import { validationBeforeWriteComment } from '@/utils/mbtiTest';
 
 import { CommentBodyWrap, CommentDetailWrap, CommentText, EachCommentWrap } from '@/components/base/styledComponents';
 import { Image } from '@/components/ui/CommonElements';
 
-export default function CommentBody({ testId, commentData, userInfo, setComment, page }: Base.CommentBodyProp) {
+export default function CommentBody({ commentData, userInfo, setAction }: Base.CommentBodyProp) {
   const [isModifying, setIsModifying] = useState(Array(commentData.length).fill(false));
   const [newValue, setNewValue] = useState('');
 
@@ -45,15 +45,9 @@ export default function CommentBody({ testId, commentData, userInfo, setComment,
     };
 
     await updateComment(headers, body);
-    await getMbtiTestCommentData(testId, 0).then((response) => {
-      doSetActionWithNewValue(null, setComment, null, sortCommentByDate(response?.dataList.commentDTOList));
-      doSetActionWithNewValue(isModifying, setIsModifying, index, false);
 
-      page.setHasNextPage(response?.dataList.hasNextPage);
-      page.setCommentPage(1);
-
-      setNewValue('');
-    });
+    setAction(`update ${new Date().toString()}`);
+    doSetActionWithNewValue(isModifying, setIsModifying, index, false);
   };
 
   const handleClickCommentUpdate = (index: number) => doSetActionWithNewValue(isModifying, setIsModifying, index, true);
@@ -69,10 +63,7 @@ export default function CommentBody({ testId, commentData, userInfo, setComment,
     };
 
     await deleteComment(headers, body);
-    await getMbtiTestCommentData(testId, 0).then((response) => {
-      doSetActionWithNewValue(null, setComment, null, sortCommentByDate(response?.dataList.commentDTOList));
-      page.setCommentPage(1);
-    });
+    setAction(`delete ${new Date().toString()}`);
   };
 
   const handleClickCommentCancel = (index: number) =>

--- a/apps/client/components/base/MbtiTestButtonArea.tsx
+++ b/apps/client/components/base/MbtiTestButtonArea.tsx
@@ -42,7 +42,7 @@ export default function MbtiTestButtonArea({ data }: Base.MbtiTestButtonAreaProp
         if (isTokenValid) {
           const needMinusValue = data.likeState;
 
-          if (likeCount) setLikeCount(needMinusValue ? likeCount - 1 : likeCount + 1); // ui 리랜더링
+          if (likeCount !== null) setLikeCount(needMinusValue ? likeCount - 1 : likeCount + 1); // ui 리랜더링
           updateLikeNumber(data.likeState, data.testId, data.memberId); // api 요청
 
           data.setLikeState(!data.likeState);

--- a/apps/client/components/base/MbtiTestButtonArea.tsx
+++ b/apps/client/components/base/MbtiTestButtonArea.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { FONT, MBTI_TEST_BUTTON_TYPE } from '@/constants/constant';
+import { FONT, IMAGE_ALT_STRING, MBTI_TEST_BUTTON_TYPE } from '@/constants/constant';
 import { MbtiTestShareImage } from '@/public/images/mbtiTest';
 import { MbtiTestLinkCopyImage, MbtiTestLinkCopiedImage } from '@/public/images/mbtiTest';
 import { atomlogInState } from '@/recoil/atoms';
@@ -58,7 +58,13 @@ export default function MbtiTestButtonArea({ data }: Base.MbtiTestButtonAreaProp
     <Wrap_mediaquery justifyContent="space-evenly">
       {imageDetailAraay.map((e, i) => (
         <ButtonTextWrap key={e.imageUrl + i}>
-          <Image src={e.imageUrl} width="2rem" margin="0 0 0.2rem 0" onClick={() => handleClickButton(e.type)} />
+          <Image
+            src={e.imageUrl}
+            width="2rem"
+            margin="0 0 0.2rem 0"
+            onClick={() => handleClickButton(e.type)}
+            alt={IMAGE_ALT_STRING + '기능 버튼'}
+          />
           <ButtonText>{e.text}</ButtonText>
           {e.type === MBTI_TEST_BUTTON_TYPE.LIKE && <ButtonText color={FONT.COLOR.DEEPGRAY}>{likeCount}</ButtonText>}
         </ButtonTextWrap>

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -95,7 +95,7 @@ export default function MbtiTestCommentArea({
         <button onClick={handleClickCommentSubmitButton} />
       </CommentTextBoxWrap>
 
-      <CommentBody commentData={comment.data} />
+      <CommentBody commentData={comment.data} value={value} userInfo={userInfo} />
     </Wrap_mediaquery>
   );
 }

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -67,9 +67,15 @@ export default function MbtiTestCommentArea({
   return (
     <Wrap_mediaquery alignItems="center" flexDirection="column">
       <CommentHeaderWrap>
-        <Image src={MbtiTestCommentImage.src} width="1rem" />
-        <CommentHeaderText>댓글</CommentHeaderText>
-        <CommentHeaderText color={FONT.COLOR.DEEPGRAY}>{commentCount}</CommentHeaderText>
+        <div>
+          <Image src={MbtiTestCommentImage.src} width="1rem" />
+          <CommentHeaderText>댓글</CommentHeaderText>
+          <CommentHeaderText color={FONT.COLOR.DEEPGRAY}>{commentCount}</CommentHeaderText>
+        </div>
+        <div>
+          <p>{value.length}/</p>
+          <p>100</p>
+        </div>
       </CommentHeaderWrap>
 
       <CommentTextBoxWrap>
@@ -78,6 +84,8 @@ export default function MbtiTestCommentArea({
           onKeyDown={handleKeyDown}
           onChange={(event) => handleChangeInputValue(event)}
           value={value}
+          maxLength={100}
+          borderBottom={value.length >= 100 ? '2px solid red' : ''}
         />
         <button onClick={handleClickCommentSubmitButton} />
       </CommentTextBoxWrap>

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -6,19 +6,16 @@ import { FONT, KEY, LOGIN, MESSAGE } from '@/constants/constant';
 import { MbtiTestCommentImage } from '@/public/images/mbtiTest';
 import { atomlogInState } from '@/recoil/atoms';
 import { getAllCommentData, submitComment } from '@/services';
-import { checkCommentAddValidity, formatTimeDifference, getHeaders } from '@/utils/common';
+import { checkCommentAddValidity, getHeaders } from '@/utils/common';
 import { tokenValidate } from '@/utils/logIn';
 import { sortCommentByDate } from '@/utils/mbtiTest';
 
+import CommentBody from '@/components/base/CommentBody';
 import {
-  CommentBodyWrap,
-  CommentDetailWrap,
   CommentHeaderText,
   CommentHeaderWrap,
-  CommentText,
   CommentTextBox,
   CommentTextBoxWrap,
-  EachCommentWrap,
 } from '@/components/base/styledComponents';
 import { Image } from '@/components/ui/CommonElements';
 import { Wrap_mediaquery } from '@/components/ui/Wrap';
@@ -98,19 +95,7 @@ export default function MbtiTestCommentArea({
         <button onClick={handleClickCommentSubmitButton} />
       </CommentTextBoxWrap>
 
-      <CommentBodyWrap>
-        {comment.data?.map((el: Base.MbtiTestCommentData) => (
-          <EachCommentWrap key={el.id}>
-            <Image src={el.thumbnailImage} width="2.5rem" height="2.5rem" borderRadius="1rem" />
-            <CommentDetailWrap>
-              <CommentText
-                color={FONT.COLOR.DEEPGRAY}
-              >{`${el.username} · ${formatTimeDifference(el.commentDate)}`}</CommentText>
-              <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>
-            </CommentDetailWrap>
-          </EachCommentWrap>
-        ))}
-      </CommentBodyWrap>
+      <CommentBody commentData={comment.data} />
     </Wrap_mediaquery>
   );
 }

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { FONT, KEY, LOGIN } from '@/constants/constant';
+import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
 import { MbtiTestCommentImage } from '@/public/images/mbtiTest';
 import { atomlogInState } from '@/recoil/atoms';
 import { getAllCommentData, submitComment } from '@/services';
@@ -58,7 +58,7 @@ export default function MbtiTestCommentArea({
     <Wrap_mediaquery alignItems="center" flexDirection="column">
       <CommentHeaderWrap>
         <div>
-          <Image src={MbtiTestCommentImage.src} width="1rem" />
+          <Image src={MbtiTestCommentImage.src} width="1rem" alt={IMAGE_ALT_STRING + '코멘트 아이콘'} />
           <CommentHeaderText>댓글</CommentHeaderText>
           <CommentHeaderText color={FONT.COLOR.DEEPGRAY}>{commentCount}</CommentHeaderText>
         </div>

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
@@ -26,12 +26,17 @@ export default function MbtiTestCommentArea({
   commentPageSet,
   mbtiTestCommentData,
   hasNextPageComment,
+  setAction,
 }: Base.MbtiTestCommentAreaProp) {
   const router = useRouter();
   const [value, setValue] = useState('');
   const [comment, setComment] = useState(sortCommentByDate(mbtiTestCommentData));
   const [hasNextPage, setHasNextPage] = useState(hasNextPageComment);
   const [userInfo, setUserInfo] = useRecoilState(atomlogInState);
+
+  useEffect(() => {
+    setComment(sortCommentByDate(mbtiTestCommentData));
+  }, [mbtiTestCommentData]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === KEY.ENTER && !event.nativeEvent.isComposing) handleClickCommentSubmit();
@@ -51,11 +56,10 @@ export default function MbtiTestCommentArea({
     };
 
     await submitComment(headers, body);
-    await getMbtiTestCommentData(testId, 0).then((response) => {
-      doSetActionWithNewValue(comment, setComment, null, sortCommentByDate(response?.dataList.commentDTOList));
-      setUserInfo((prev: Model.LogInState) => ({ ...prev, [LOGIN.LAST_COMMENT_TIME]: new Date() }));
-      setValue('');
-    });
+    setAction(`add ${new Date().toString()}`);
+
+    setUserInfo((prev: Model.LogInState) => ({ ...prev, [LOGIN.LAST_COMMENT_TIME]: new Date() }));
+    setValue('');
   };
 
   const handleClickSeeMoreComment = () => {
@@ -95,13 +99,7 @@ export default function MbtiTestCommentArea({
         <button onClick={handleClickCommentSubmit} />
       </CommentTextBoxWrap>
 
-      <CommentBody
-        testId={testId}
-        commentData={comment}
-        userInfo={userInfo}
-        setComment={setComment}
-        page={{ setHasNextPage, setCommentPage: commentPageSet.setCommentPage }}
-      />
+      <CommentBody testId={testId} commentData={comment} userInfo={userInfo} setAction={setAction} />
 
       {hasNextPage && <SeeMoreButton onClick={handleClickSeeMoreComment} />}
     </Wrap_mediaquery>

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -98,7 +98,7 @@ export default function MbtiTestCommentArea({
               <CommentText
                 color={FONT.COLOR.DEEPGRAY}
               >{`${el.username} · ${formatTimeDifference(el.commentDate)}`}</CommentText>
-              <CommentText padding="0.2rem 0 0 0">{el.content}</CommentText>
+              <CommentText padding="0.2rem 4rem 0 0">{el.content}</CommentText>
             </CommentDetailWrap>
           </EachCommentWrap>
         ))}

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -61,7 +61,7 @@ export default function MbtiTestCommentArea({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === KEY.ENTER) handleClickCommentSubmitButton();
+    if (event.key === KEY.ENTER && !event.nativeEvent.isComposing) handleClickCommentSubmitButton();
   };
 
   return (

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -42,9 +42,10 @@ export default function MbtiTestCommentArea({
 
   const handleClickCommentSubmitButton = async () => {
     const isTokenValid = tokenValidate(userInfo);
-    const canAddComment = checkCommentAddValidity(new Date(), new Date(userInfo[LOGIN.LAST_COMMENT_TIME]));
+    const prevCommentAddedDate = userInfo[LOGIN.LAST_COMMENT_TIME] ? new Date(userInfo[LOGIN.LAST_COMMENT_TIME]) : null;
+    const canAddComment = checkCommentAddValidity(new Date(), prevCommentAddedDate);
 
-    if (!isTokenValid) router.push('/login');
+    if (!isTokenValid) return router.push('/login');
     if (value === '') return;
     if (!canAddComment) return alert(MESSAGE.COMMENT_TIME);
 

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -16,6 +16,7 @@ import {
   CommentHeaderWrap,
   CommentTextBox,
   CommentTextBoxWrap,
+  SeeMoreCommentWrap,
 } from '@/components/base/styledComponents';
 import { Image } from '@/components/ui/CommonElements';
 import { Wrap_mediaquery } from '@/components/ui/Wrap';
@@ -101,7 +102,11 @@ export default function MbtiTestCommentArea({
 
       <CommentBody testId={testId} commentData={comment} userInfo={userInfo} setAction={setAction} />
 
-      {hasNextPage && <SeeMoreButton onClick={handleClickSeeMoreComment} />}
+      {hasNextPage && (
+        <SeeMoreCommentWrap>
+          <SeeMoreButton onClick={handleClickSeeMoreComment} />
+        </SeeMoreCommentWrap>
+      )}
     </Wrap_mediaquery>
   );
 }

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -6,7 +6,7 @@ import { FONT, IMAGE_ALT_STRING, KEY, LOGIN } from '@/constants/constant';
 import { MbtiTestCommentImage } from '@/public/images/mbtiTest';
 import { atomlogInState } from '@/recoil/atoms';
 import { getMbtiTestCommentData, submitComment } from '@/services';
-import { doSetActionWithNewValue, getHeaders } from '@/utils/common';
+import { doSetStateWithNewState, getHeaders } from '@/utils/common';
 import { sortCommentByDate, validationBeforeWriteComment } from '@/utils/mbtiTest';
 
 import { SeeMoreButton } from '../ui/Button';
@@ -66,7 +66,7 @@ export default function MbtiTestCommentArea({
     getMbtiTestCommentData(testId, commentPageSet.commentPage).then((response) => {
       const newArr = [...comment, response?.dataList.commentDTOList].flat();
 
-      doSetActionWithNewValue(null, setComment, null, newArr);
+      doSetStateWithNewState(null, setComment, null, newArr);
       setHasNextPage(response?.dataList.hasNextPage);
     });
 

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -40,6 +40,7 @@ export default function MbtiTestCommentArea({
   const handleClickCommentSubmitButton = async () => {
     const isTokenValid = tokenValidate(userInfo);
     if (!isTokenValid) router.push('/login');
+    if (value === '') return;
 
     const headers = getHeaders(true);
     const body = {

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import { FONT, LOGIN } from '@/constants/constant';
+import { FONT, KEY, LOGIN } from '@/constants/constant';
 import { MbtiTestCommentImage } from '@/public/images/mbtiTest';
 import { atomlogInState } from '@/recoil/atoms';
 import { getAllCommentData, submitComment } from '@/services';
@@ -59,6 +59,10 @@ export default function MbtiTestCommentArea({
     });
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === KEY.ENTER) handleClickCommentSubmitButton();
+  };
+
   return (
     <Wrap_mediaquery alignItems="center" flexDirection="column">
       <CommentHeaderWrap>
@@ -70,6 +74,7 @@ export default function MbtiTestCommentArea({
       <CommentTextBoxWrap>
         <CommentTextBox
           placeholder="나쁜말 하면 신고합니다 ㅇㅅㅇ"
+          onKeyDown={handleKeyDown}
           onChange={(event) => handleChangeInputValue(event)}
           value={value}
         />

--- a/apps/client/components/base/MbtiTestCommentArea.tsx
+++ b/apps/client/components/base/MbtiTestCommentArea.tsx
@@ -95,7 +95,7 @@ export default function MbtiTestCommentArea({
         <button onClick={handleClickCommentSubmitButton} />
       </CommentTextBoxWrap>
 
-      <CommentBody commentData={comment.data} value={value} userInfo={userInfo} />
+      <CommentBody commentData={comment.data} userInfo={userInfo} />
     </Wrap_mediaquery>
   );
 }

--- a/apps/client/components/base/MbtiTestContent.tsx
+++ b/apps/client/components/base/MbtiTestContent.tsx
@@ -1,4 +1,4 @@
-import { FONT, CONST_MAIN_PAGE } from '@/constants/constant';
+import { FONT, CONST_MAIN_PAGE, IMAGE_ALT_STRING } from '@/constants/constant';
 import { MbtiTestCommentCountImage, MbtiTestLikeCountImage, MbtiTestPlayCountImage } from '@/public/images/mbtiTest';
 
 import { WrapForMbtiTestCountImageArea, MbtiTestCountImageText } from '@/components/base/styledComponents';
@@ -58,15 +58,15 @@ export function MbtiTestCountImageArea({ countData }: Base.MbtiTestCountImageAre
   return (
     <WrapForMbtiTestCountImageArea position="relative" top="-2.5rem">
       <WrapForMbtiTestCountImageArea>
-        <Image src={MbtiTestPlayCountImage.src} margin="-0.1rem 0.2rem 0 0" />
+        <Image src={MbtiTestPlayCountImage.src} margin="-0.1rem 0.2rem 0 0" alt={IMAGE_ALT_STRING + '실행 횟수'} />
         <MbtiTestCountImageText>{countData?.playCount}</MbtiTestCountImageText>
       </WrapForMbtiTestCountImageArea>
       <WrapForMbtiTestCountImageArea>
-        <Image src={MbtiTestLikeCountImage.src} margin="-0.2rem 0.2rem 0 0" />
+        <Image src={MbtiTestLikeCountImage.src} margin="-0.2rem 0.2rem 0 0" alt={IMAGE_ALT_STRING + '좋아요 횟수'} />
         <MbtiTestCountImageText>{countData?.likeCount}</MbtiTestCountImageText>
       </WrapForMbtiTestCountImageArea>
       <WrapForMbtiTestCountImageArea>
-        <Image src={MbtiTestCommentCountImage.src} />
+        <Image src={MbtiTestCommentCountImage.src} alt={IMAGE_ALT_STRING + '코멘트 개수'} />
         <MbtiTestCountImageText padding="0 0 0 0.3rem">{countData?.commentCount}</MbtiTestCountImageText>
       </WrapForMbtiTestCountImageArea>
     </WrapForMbtiTestCountImageArea>

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -199,6 +199,11 @@ export const CommentTextBoxWrap = styled(Div)`
     margin-right: 0.5rem;
   }
 `;
+
+export const SeeMoreCommentWrap = styled(Div)`
+margin-top: 1.5rem;
+`
+
 export const CommentTextBox = styled.input<{ borderBottom: string }>`
   width: ${MEDIAQUERY.WIDTH_370};
   height: 2.5rem;

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -194,7 +194,7 @@ export const CommentTextBox = styled.input`
   padding: 0 4rem 0 1rem;
   margin: 0.3rem 0;
   background-color: ${FONT.COLOR.LIGHTGRAY};
-  font-size: 1rem;
+  font-size: ${FONT.SIZE.SMALL};
   color: ${FONT.COLOR.DEEPGRAY};
   border-radius: 0.3rem;
   border-style: none;

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -257,7 +257,7 @@ export const EachCommentWrap = styled(Div)`
   }
 `;
 
-export const CommentDetailWrap = styled(Div)`
+export const CommentDetailWrap = styled(Div)<{ borderBottom: string }>`
   display: flex;
   flex-direction: column;
   padding: 0.2rem 0 0 0.7rem;
@@ -265,6 +265,27 @@ export const CommentDetailWrap = styled(Div)`
 
   @media (max-width: ${MEDIAQUERY.WIDTH_375}) {
     width: ${MEDIAQUERY.WIDTH_340};
+  }
+
+  & > div > input {
+    border: none;
+    border-bottom: ${(prop) => prop.borderBottom};
+    width: ${MEDIAQUERY.WIDTH_315};
+    padding: 0 3.3rem 0.2rem 0;
+    outline: none;
+    font-size: ${FONT.SIZE.SMALL};
+  }
+
+  & > div > div {
+    display: flex;
+  }
+
+  & > div > div {
+    position: absolute;
+    right: 0.3rem;
+    bottom: 0;
+    color: ${FONT.COLOR.DEEPGRAY};
+    font-size: ${FONT.SIZE.SMALL};
   }
 `;
 

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -241,10 +241,23 @@ export const CommentDetailWrap = styled(Div)`
   display: flex;
   flex-direction: column;
   padding: 0.2rem 0 0 0.7rem;
+  width: ${MEDIAQUERY.WIDTH_370};
+
+  @media (max-width: ${MEDIAQUERY.WIDTH_375}) {
+    width: ${MEDIAQUERY.WIDTH_340};
+  }
 `;
 
 export const CommentText = styled(Text)`
   font-size: ${FONT.SIZE.SMALL};
   color: ${(prop) => prop.color ?? FONT.COLOR.BLACK};
   padding: ${(prop) => prop.padding ?? ''};
+  word-wrap: break-word;
+  text-align: justify;
+
+  width: ${MEDIAQUERY.WIDTH_370};
+
+  @media (max-width: ${MEDIAQUERY.WIDTH_375}) {
+    width: ${MEDIAQUERY.WIDTH_340};
+  }
 `;

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -17,6 +17,7 @@ export const HeaderButton = styled.button<CommonStyledComponents.HeaderButtonPro
   background-position: center;
   background-size: contain;
   margin: 0 1rem;
+  cursor: pointer;
 `;
 
 // MyFooter.tsx

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -235,6 +235,26 @@ export const CommentBodyWrap = styled(Div)`
 export const EachCommentWrap = styled(Div)`
   padding-top: 1rem;
   display: flex;
+  position: relative;
+
+  & > div:last-child {
+    width: 4rem;
+    position: absolute;
+    right: 0.5rem;
+    top: 1.1rem;
+    display: flex;
+    justify-content: end;
+
+    & > p {
+      color: ${FONT.COLOR.DEEPGRAY};
+      font-size: ${FONT.SIZE.SMALL};
+      cursor: pointer;
+    }
+
+    & > p:last-child {
+      margin-left: 0.4rem;
+    }
+  }
 `;
 
 export const CommentDetailWrap = styled(Div)`

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -201,8 +201,8 @@ export const CommentTextBoxWrap = styled(Div)`
 `;
 
 export const SeeMoreCommentWrap = styled(Div)`
-margin-top: 1.5rem;
-`
+  margin-top: 1.5rem;
+`;
 
 export const CommentTextBox = styled.input<{ borderBottom: string }>`
   width: ${MEDIAQUERY.WIDTH_370};

--- a/apps/client/components/base/styledComponents/index.ts
+++ b/apps/client/components/base/styledComponents/index.ts
@@ -158,8 +158,18 @@ export const ButtonText = styled(Text)`
 // MbtiTestCommentArea.tsx
 export const CommentHeaderWrap = styled(Div)`
   display: flex;
+  justify-content: space-between;
   width: ${MEDIAQUERY.WIDTH_370};
   margin-bottom: 0.5rem;
+
+  & > div {
+    display: flex;
+  }
+
+  & > div:last-child {
+    color: ${FONT.COLOR.DEEPGRAY};
+    font-size: ${FONT.SIZE.SMALL};
+  }
 
   @media (max-width: ${MEDIAQUERY.WIDTH_375}) {
     width: ${MEDIAQUERY.WIDTH_340};
@@ -188,7 +198,7 @@ export const CommentTextBoxWrap = styled(Div)`
     margin-right: 0.5rem;
   }
 `;
-export const CommentTextBox = styled.input`
+export const CommentTextBox = styled.input<{ borderBottom: string }>`
   width: ${MEDIAQUERY.WIDTH_370};
   height: 2.5rem;
   padding: 0 4rem 0 1rem;
@@ -198,6 +208,7 @@ export const CommentTextBox = styled.input`
   color: ${FONT.COLOR.DEEPGRAY};
   border-radius: 0.3rem;
   border-style: none;
+  border-bottom: ${(prop) => prop.borderBottom ?? ''};
 
   &::placeholder {
     font-size: ${FONT.SIZE.SMALL};

--- a/apps/client/components/base/styledComponents/types.d.ts
+++ b/apps/client/components/base/styledComponents/types.d.ts
@@ -22,7 +22,7 @@ declare namespace CommonStyledComponents {
 
   type SideMenuState = {
     showSideMenu: boolean;
-    setShowSideMenu: React.Dispatch<React.SetStateAction<boolean>>;
+    setShowSideMenu: SetState.Boolean;
   };
 
   type SetLogIn = (arg0: boolean) => void;

--- a/apps/client/components/base/styledComponents/types.d.ts
+++ b/apps/client/components/base/styledComponents/types.d.ts
@@ -1,17 +1,17 @@
 declare namespace CommonStyledComponents {
-  interface Show {
+  type Show = {
     setShowSideMenu: (arg0: boolean) => void;
     showSideMenu: boolean;
-  }
+  };
 
-  interface SideMenuProp {
+  type SideMenuProp = {
     show: Show;
-  }
+  };
 
-  interface SideMenuDivProp {
+  type SideMenuDivProp = {
     height?: string;
     show: Show;
-  }
+  };
 
   type HeaderButtonProp = {
     width: string;

--- a/apps/client/components/base/types.d.ts
+++ b/apps/client/components/base/types.d.ts
@@ -53,16 +53,13 @@ declare namespace Base {
     };
     mbtiTestCommentData: Model.CommentData[];
     hasNextPageComment: boolean;
+    setAction: React.Dispatch<React.SetStateAction<string>>;
   };
 
   type CommentBodyProp = {
     testId: string | null;
     commentData: Model.CommentData[];
     userInfo: Model.LogInState;
-    setComment: React.Dispatch<React.SetStateAction<Model.CommentData[]>>;
-    page: {
-      setHasNextPage: React.Dispatch<React.SetStateAction<boolean>>;
-      setCommentPage: React.Dispatch<React.SetStateAction<number>>;
-    };
+    setAction: React.Dispatch<React.SetStateAction<string>>;
   };
 }

--- a/apps/client/components/base/types.d.ts
+++ b/apps/client/components/base/types.d.ts
@@ -47,8 +47,6 @@ declare namespace Base {
   type MbtiTestCommentAreaProp = {
     testId: string | null;
     commentCount: number | null;
-    mbtiTestCommentData: Model.PreviewMbtiTest.mbtiTestCommentData;
+    mbtiTestCommentData: Model.CommentData[];
   };
-
-  type MbtiTestCommentData = Model.PreviewMbtiTest.mbtiTestCommentData;
 }

--- a/apps/client/components/base/types.d.ts
+++ b/apps/client/components/base/types.d.ts
@@ -40,7 +40,7 @@ declare namespace Base {
       likeCount: number | null;
       testId: string | null;
       memberId: string;
-      setLikeState: React.Dispatch<React.SetStateAction<boolean>>;
+      setLikeState: SetState.Boolean;
     };
   };
 
@@ -49,17 +49,17 @@ declare namespace Base {
     commentCount: number | null;
     commentPageSet: {
       commentPage: number;
-      setCommentPage: React.Dispatch<React.SetStateAction<number>>;
+      setCommentPage: SetState.Number;
     };
     mbtiTestCommentData: Model.CommentData[];
     hasNextPageComment: boolean;
-    setAction: React.Dispatch<React.SetStateAction<string>>;
+    setAction: SetState.String;
   };
 
   type CommentBodyProp = {
     testId: string | null;
     commentData: Model.CommentData[];
     userInfo: Model.LogInState;
-    setAction: React.Dispatch<React.SetStateAction<string>>;
+    setAction: SetState.String;
   };
 }

--- a/apps/client/components/base/types.d.ts
+++ b/apps/client/components/base/types.d.ts
@@ -45,6 +45,7 @@ declare namespace Base {
   };
 
   type MbtiTestCommentAreaProp = {
+    testId: string | null;
     commentCount: number | null;
     mbtiTestCommentData: Model.PreviewMbtiTest.mbtiTestCommentData;
   };

--- a/apps/client/components/base/types.d.ts
+++ b/apps/client/components/base/types.d.ts
@@ -47,6 +47,22 @@ declare namespace Base {
   type MbtiTestCommentAreaProp = {
     testId: string | null;
     commentCount: number | null;
+    commentPageSet: {
+      commentPage: number;
+      setCommentPage: React.Dispatch<React.SetStateAction<number>>;
+    };
     mbtiTestCommentData: Model.CommentData[];
+    hasNextPageComment: boolean;
+  };
+
+  type CommentBodyProp = {
+    testId: string | null;
+    commentData: Model.CommentData[];
+    userInfo: Model.LogInState;
+    setComment: React.Dispatch<React.SetStateAction<Model.CommentData[]>>;
+    page: {
+      setHasNextPage: React.Dispatch<React.SetStateAction<boolean>>;
+      setCommentPage: React.Dispatch<React.SetStateAction<number>>;
+    };
   };
 }

--- a/apps/client/components/ui/Button.tsx
+++ b/apps/client/components/ui/Button.tsx
@@ -34,7 +34,7 @@ export function SeeMoreButton({ onClick }: Ui.SeeMoreButtonProp) {
   return (
     <SeeMoreButtonWrap onClick={onClick}>
       <p>더보기</p>
-      <Image src={SeeMoreIconImage.src} alt={`${IMAGE_ALT_STRING} 더보기 버튼`} width="0.8rem" />
+      <Image src={SeeMoreIconImage.src} alt={IMAGE_ALT_STRING + '더보기 버튼'} width="0.8rem" />
     </SeeMoreButtonWrap>
   );
 }

--- a/apps/client/constants/constant.ts
+++ b/apps/client/constants/constant.ts
@@ -14,11 +14,14 @@ export const LOGIN = {
   USER_NAME: 'mbUserName',
   COUPANG_VISIT: 'mbCoupangVisitDate',
   ROLE_ADMIN: 'ROLE_ADMIN',
+  LAST_COMMENT_TIME: 'mbLastCommentTime',
 };
 
 //Alert msg
-export const ALL_FULLFILL = '모든 항목을 입력해주세요.';
-export const COMMENT_TIME = '코멘트 등록은 20초 간격으로 가능합니다.';
+
+export const MESSAGE = {
+  COMMENT_TIME: '코멘트 등록은 20초 간격으로 가능합니다.',
+};
 
 //OG Image url
 export const OG_STANDARD_IMAGE = 'https://i.ibb.co/mvVsyTr/Frame-17.png';

--- a/apps/client/constants/constant.ts
+++ b/apps/client/constants/constant.ts
@@ -31,6 +31,7 @@ export const OG_MBTI_TEST_GO = 'https://i.ibb.co/P4KyxjF/image.png'; // 이건 �
 
 // 화면, 폰트
 export const MEDIAQUERY = {
+  WIDTH_315: '315px',
   WIDTH_340: '340px',
   WIDTH_345: '345px',
   WIDTH_375: '375px',
@@ -43,6 +44,7 @@ export const FONT = {
   COLOR: {
     DARKGRAY: '#8f8f8f',
     DEEPGRAY: '#979797',
+    MEDIUMGRAY: '#cdcdcd',
     LIGHTGRAY: '#f2f2f2',
     WHITE: 'white',
     BLACK: 'black',

--- a/apps/client/constants/constant.ts
+++ b/apps/client/constants/constant.ts
@@ -18,7 +18,6 @@ export const LOGIN = {
 
 //Alert msg
 export const ALL_FULLFILL = '모든 항목을 입력해주세요.';
-export const LENGTH_OVER_500 = '500자 이상으로 작성한 항목이 존재합니다.';
 export const COMMENT_TIME = '코멘트 등록은 20초 간격으로 가능합니다.';
 
 //OG Image url
@@ -114,4 +113,9 @@ export const CONST_FOOTER = {
   COPYRIGHT: '© 2023 MongMoongCrew. All rights reserved',
   BUTTON_IMG_URL: [GitHubImage.src, InstagramImage.src],
   LINK_URL: ['https://github.com/Moorisong/MongBit_FE_Next', 'https://www.instagram.com/mongbit_'],
+};
+
+// key down
+export const KEY = {
+  ENTER: 'Enter',
 };

--- a/apps/client/containers/needLogIn/index.tsx
+++ b/apps/client/containers/needLogIn/index.tsx
@@ -15,15 +15,6 @@ export default function Login() {
     ? `https://kauth.kakao.com/oauth/authorize?client_id=3245a5f9cb8303814aadbe1eb65b2e73&redirect_uri=${process.env.NEXT_PUBLIC_FE_URL_CLIENT}/login/oauth2/kakao/code&response_type=code`
     : `https://kauth.kakao.com/oauth/authorize?client_id=3245a5f9cb8303814aadbe1eb65b2e73&redirect_uri=${DOMAIN_BE_PROD}/login/oauth2/kakao/code&response_type=code`;
 
-  // const kakaoLogin = () => {
-  //   window.location.href = url;
-  // };
-
-  // 어드민
-  // useEffect(() => {
-  //   addDailyVisitCount();
-  // }, []);
-
   return (
     <Wrap_mediaquery flexDirection="column" justifyContent="center" alignItems="center" padding="3rem 0 0 0 ">
       <ContentText fontSize={FONT.SIZE.MEDIUM} color={FONT.COLOR.BLACK}>

--- a/apps/client/containers/previewMbtiTest/index.tsx
+++ b/apps/client/containers/previewMbtiTest/index.tsx
@@ -76,7 +76,7 @@ export default function PreviewMbtiTest({ mbtiTestData }: Model.PreviewMbtiTest)
 
   const contentTextArray = mbtiTestData?.test.content.split('<br>');
 
-  if (data.mbtiTestData.likeCount) {
+  if (data.mbtiTestData.likeCount !== null) {
     return (
       <Wrap_mediaquery flexDirection="column" alignItems="center">
         {/* Mbti 테스트 정보 */}

--- a/apps/client/containers/previewMbtiTest/index.tsx
+++ b/apps/client/containers/previewMbtiTest/index.tsx
@@ -30,9 +30,11 @@ export default function PreviewMbtiTest({ mbtiTestData }: Model.PreviewMbtiTest)
   const userInfo = useRecoilValue(atomlogInState);
   const containerRef = useRef(null);
   const [likeState, setLikeState] = useState(false);
+  const [commentPage, setCommentPage] = useState(0);
   const [data, setData] = useState({
     mbtiTestData: { likeCount: null, commentCount: null },
     mbtiTestCommentData: null,
+    hasNextPageComment: false,
   });
 
   const testId = mbtiTestData ? mbtiTestData.test.id : null;
@@ -44,7 +46,7 @@ export default function PreviewMbtiTest({ mbtiTestData }: Model.PreviewMbtiTest)
     getLikeState(testId, userInfo[LOGIN.USER_MEMBER_ID]).then((response) => setLikeState(response?.dataList));
   }, []);
 
-  useLoadMbtiTestDatas(testId, setData);
+  useLoadMbtiTestDatas(testId, setData, { commentPage, setCommentPage });
 
   const likeImageUrl = likeState ? MbtiTestLikedImage.src : MbtiTestLikeImage.src;
   const buttonAreaProp = {
@@ -88,7 +90,9 @@ export default function PreviewMbtiTest({ mbtiTestData }: Model.PreviewMbtiTest)
         <MbtiTestCommentArea
           testId={testId}
           commentCount={data.mbtiTestData?.commentCount}
+          commentPageSet={{ commentPage, setCommentPage }}
           mbtiTestCommentData={data.mbtiTestCommentData ?? []}
+          hasNextPageComment={data.hasNextPageComment}
         />
       </Wrap_mediaquery>
     );

--- a/apps/client/containers/previewMbtiTest/index.tsx
+++ b/apps/client/containers/previewMbtiTest/index.tsx
@@ -86,6 +86,7 @@ export default function PreviewMbtiTest({ mbtiTestData }: Model.PreviewMbtiTest)
 
         {/* Mbti 테스트 댓글 영역 */}
         <MbtiTestCommentArea
+          testId={testId}
           commentCount={data.mbtiTestData?.commentCount}
           mbtiTestCommentData={data.mbtiTestCommentData ?? []}
         />

--- a/apps/client/hooks/hooks.ts
+++ b/apps/client/hooks/hooks.ts
@@ -21,22 +21,29 @@ export function useAnimationEffect(containerRef: Hooks.containerRefCurrent, anim
   }, [containerRef]);
 }
 
-export function useLoadMbtiTestDatas(testId: string | null, setData: Hooks.setData) {
+export function useLoadMbtiTestDatas(
+  testId: string | null,
+  setData: Hooks.SetData,
+  { commentPage, setCommentPage }: Hooks.CommentPage,
+) {
   useEffect(() => {
     if (!testId) return;
 
     getMbtiTestData(testId).then(
       // mbti test 데이터 조회가 성공하면
-      (responseTest) =>
-        getMbtiTestCommentData(testId).then(
+      (responseTest) => {
+        getMbtiTestCommentData(testId, commentPage).then(
           // mbti 코멘트 데이터 조회
           (responseComment) =>
             setData((prev) => ({
               ...prev,
               mbtiTestData: responseTest?.dataList,
-              mbtiTestCommentData: responseComment?.dataList,
+              mbtiTestCommentData: responseComment?.dataList.commentDTOList,
+              hasNextPageComment: responseComment?.dataList.hasNextPage,
             })),
-        ),
+        );
+        setCommentPage(commentPage + 1);
+      },
     );
   }, []);
 }

--- a/apps/client/hooks/types.d.ts
+++ b/apps/client/hooks/types.d.ts
@@ -3,7 +3,16 @@ declare namespace Hooks {
     current: HTMLDivElement | null;
   };
 
-  type setData = React.Dispatch<
-    React.SetStateAction<{ mbtiTestData: { likeCount: null; commentCount: null }; mbtiTestCommentData: null }>
+  type SetData = React.Dispatch<
+    React.SetStateAction<{
+      mbtiTestData: { likeCount: null; commentCount: null };
+      mbtiTestCommentData: null;
+      hasNextPageComment: boolean;
+    }>
   >;
+
+  type CommentPage = {
+    commentPage: number;
+    setCommentPage: React.Dispatch<React.SetStateAction<number>>;
+  };
 }

--- a/apps/client/hooks/types.d.ts
+++ b/apps/client/hooks/types.d.ts
@@ -13,6 +13,6 @@ declare namespace Hooks {
 
   type CommentPage = {
     commentPage: number;
-    setCommentPage: React.Dispatch<React.SetStateAction<number>>;
+    setCommentPage: SetState.Number;
   };
 }

--- a/apps/client/services/index.tsx
+++ b/apps/client/services/index.tsx
@@ -43,8 +43,8 @@ const doApi = async ({ url, method, headers, body }: Services.FetchClientProp) =
 export const getMbtiTestData = (testId: string) => doApi({ url: `/api/v1/tests/test/${testId}`, method: 'GET' });
 export const getLatestMbtiTestData = (count: number) => doApi({ url: `/api/v1/tests/0/${count}`, method: 'GET' });
 export const getAllMbtiTestData = (count: number) => doApi({ url: `/api/v1/tests/0/${count}`, method: 'GET' });
-export const getMbtiTestCommentData = (testId: string) =>
-  doApi({ url: `/api/v1/test/comments/${testId}`, method: 'GET' });
+export const getMbtiTestCommentData = (testId: string | null, page: number) =>
+  doApi({ url: `/api/v1/test/comments/${testId}/page/${page}`, method: 'GET' });
 
 export const getLikeState = (testId: string | null, memberId: string | undefined) =>
   doApi({ url: `/api/v1/test/${testId}/${memberId}/like`, method: 'GET' });
@@ -58,9 +58,6 @@ export const updateLikeCount = (
 
 export const submitComment = (headers: Services.Headers, body: any) =>
   doApi({ url: `/api/v1/test/comments`, method: 'POST', headers, body });
-
-export const getAllCommentData = (testId: string | null) =>
-  doApi({ url: `/api/v1/test/comments/${testId}`, method: 'GET' });
 
 export const updateComment = (headers: Services.Headers, body: any) =>
   doApi({ url: `/api/v1/test/comments`, method: 'PATCH', headers, body });

--- a/apps/client/services/index.tsx
+++ b/apps/client/services/index.tsx
@@ -64,3 +64,6 @@ export const getAllCommentData = (testId: string | null) =>
 
 export const updateComment = (headers: Services.Headers, body: any) =>
   doApi({ url: `/api/v1/test/comments`, method: 'PATCH', headers, body });
+
+export const deleteComment = (headers: Services.Headers, body: any) =>
+  doApi({ url: `/api/v1/test/comments`, method: 'DELETE', headers, body });

--- a/apps/client/services/index.tsx
+++ b/apps/client/services/index.tsx
@@ -1,12 +1,13 @@
 import { notFound } from 'next/navigation';
 
-export const fetchClient = async ({ url, method, headers }: Services.FetchClientProp) => {
+export const fetchClient = async ({ url, method, headers, body }: Services.FetchClientProp) => {
   const isInvaildUrl = !url || typeof url !== 'string';
   if (isInvaildUrl) throw new Error('Invalid URL');
 
   const requestOption = {
     method,
     headers: headers ?? {},
+    body: body ?? null,
   };
 
   const res = await fetch(`${process.env.NEXT_PUBLIC_BE_URL_PROD}${url}`, requestOption);
@@ -28,27 +29,35 @@ export const fetchClient = async ({ url, method, headers }: Services.FetchClient
   return { dataList, headers: res.headers };
 };
 
-export const getData = async (url: string, method: string, headers?: Services.Headers) => {
+const doApi = async ({ url, method, headers, body }: Services.FetchClientProp) => {
   const fetchOption = {
     url,
     method,
     headers,
+    body: JSON.stringify(body),
   };
   return fetchClient(fetchOption);
 };
 
 // api 요청 목록
-export const getMbtiTestData = (testId: string) => getData(`/api/v1/tests/test/${testId}`, 'GET');
-export const getLatestMbtiTestData = (count: number) => getData(`/api/v1/tests/0/${count}`, 'GET');
-export const getAllMbtiTestData = (count: number) => getData(`/api/v1/tests/0/${count}`, 'GET');
-export const getMbtiTestCommentData = (testId: string) => getData(`/api/v1/test/comments/${testId}`, 'GET');
+export const getMbtiTestData = (testId: string) => doApi({ url: `/api/v1/tests/test/${testId}`, method: 'GET' });
+export const getLatestMbtiTestData = (count: number) => doApi({ url: `/api/v1/tests/0/${count}`, method: 'GET' });
+export const getAllMbtiTestData = (count: number) => doApi({ url: `/api/v1/tests/0/${count}`, method: 'GET' });
+export const getMbtiTestCommentData = (testId: string) =>
+  doApi({ url: `/api/v1/test/comments/${testId}`, method: 'GET' });
 
 export const getLikeState = (testId: string | null, memberId: string | undefined) =>
-  getData(`/api/v1/test/${testId}/${memberId}/like`, 'GET');
+  doApi({ url: `/api/v1/test/${testId}/${memberId}/like`, method: 'GET' });
 
 export const updateLikeCount = (
   testId: string | null,
   memberId: string | undefined,
   likeState: boolean,
   headers: Services.Headers,
-) => getData(`/api/v1/test/${testId}/${memberId}/like`, likeState ? 'DELETE' : 'POST', headers);
+) => doApi({ url: `/api/v1/test/${testId}/${memberId}/like`, method: likeState ? 'DELETE' : 'POST', headers });
+
+export const submitComment = (headers: Services.Headers, body: any) =>
+  doApi({ url: `/api/v1/test/comments`, method: 'POST', headers, body });
+
+export const getAllCommentData = (testId: string | null) =>
+  doApi({ url: `/api/v1/test/comments/${testId}`, method: 'GET' });

--- a/apps/client/services/index.tsx
+++ b/apps/client/services/index.tsx
@@ -61,3 +61,6 @@ export const submitComment = (headers: Services.Headers, body: any) =>
 
 export const getAllCommentData = (testId: string | null) =>
   doApi({ url: `/api/v1/test/comments/${testId}`, method: 'GET' });
+
+export const updateComment = (headers: Services.Headers, body: any) =>
+  doApi({ url: `/api/v1/test/comments`, method: 'PATCH', headers, body });

--- a/apps/client/services/index.tsx
+++ b/apps/client/services/index.tsx
@@ -14,6 +14,8 @@ export const fetchClient = async ({ url, method, headers }: Services.FetchClient
     switch (res.status) {
       case 404:
         return notFound();
+      case 401:
+        return;
       default:
         throw new Error('Failed to fetch data');
     }

--- a/apps/client/services/types.d.ts
+++ b/apps/client/services/types.d.ts
@@ -4,9 +4,11 @@ declare namespace Services {
         Authorization: string | null;
       }
     | undefined;
+
   type FetchClientProp = {
     url: string;
     method: string;
     headers?: Headers;
+    body?: any;
   };
 }

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -64,6 +64,7 @@ declare namespace Model {
       url?: boolean | string;
     };
     key?: string;
+    mbLastCommentTime: string;
     [key: string]: string | undefined;
   };
 

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -59,18 +59,6 @@ declare namespace Model {
     };
   };
 
-  // type LogInState = {
-  //   goPage?: {
-  //     url?: boolean | string;
-  //   };
-  //   key?: string;
-  //   mbRegisterDate?: string;
-  //   mbThumbnail?: string;
-  //   [key: string]: string | undefined;
-  //   mbUserID?: string;
-  //   mbUserName?: string;
-  // };
-
   type LogInState = {
     goPage?: {
       url?: boolean | string;

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -78,3 +78,10 @@ declare namespace Model {
     thumbnailImage: string;
   };
 }
+
+declare namespace SetState {
+  type Boolean = React.Dispatch<React.SetStateAction<boolean>>;
+  type String = React.Dispatch<React.SetStateAction<string>>;
+  type Number = React.Dispatch<React.SetStateAction<number>>;
+  type Any = React.Dispatch<React.SetStateAction<any>>;
+}

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -66,4 +66,14 @@ declare namespace Model {
     key?: string;
     [key: string]: string | undefined;
   };
+
+  type CommentData = {
+    id: string;
+    memberId: string;
+    testId: string;
+    commentDate: string;
+    content: string;
+    username: string;
+    thumbnailImage: string;
+  }[];
 }

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -59,13 +59,23 @@ declare namespace Model {
     };
   };
 
-  type mbtiTestCommentData = {
-    id: string;
-    memberId: string;
-    testId: string;
-    commentDate: string;
-    content: string;
-    username: string;
-    thumbnailImage: string;
-  }[];
+  // type LogInState = {
+  //   goPage?: {
+  //     url?: boolean | string;
+  //   };
+  //   key?: string;
+  //   mbRegisterDate?: string;
+  //   mbThumbnail?: string;
+  //   [key: string]: string | undefined;
+  //   mbUserID?: string;
+  //   mbUserName?: string;
+  // };
+
+  type LogInState = {
+    goPage?: {
+      url?: boolean | string;
+    };
+    key?: string;
+    [key: string]: string | undefined;
+  };
 }

--- a/apps/client/types/types.d.ts
+++ b/apps/client/types/types.d.ts
@@ -75,5 +75,5 @@ declare namespace Model {
     content: string;
     username: string;
     thumbnailImage: string;
-  }[];
+  };
 }

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -61,7 +61,7 @@ export function checkCommentAddValidity(currentTime: Date, previousTime: Date | 
   return timeDiffInMillis >= 20000;
 }
 
-export function doSetActionWithNewValue(
+export function doSetStateWithNewState(
   prevState: any,
   setState: React.Dispatch<React.SetStateAction<any>>,
   index: number | null,

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -61,12 +61,7 @@ export function checkCommentAddValidity(currentTime: Date, previousTime: Date | 
   return timeDiffInMillis >= 20000;
 }
 
-export function doSetStateWithNewState(
-  prevState: any,
-  setState: React.Dispatch<React.SetStateAction<any>>,
-  index: number | null,
-  newValue: any,
-) {
+export function doSetStateWithNewState(prevState: any, setState: SetState.Any, index: number | null, newValue: any) {
   const newState = index === null ? newValue : [...prevState];
 
   if (index !== null) newState[index] = newValue;

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -55,8 +55,8 @@ export function formatTimeDifference(dateString: string) {
 export function checkCommentAddValidity(currentTime: Date, previousTime: Date | null) {
   // 마지막 코멘트를 등록한 시점부터 20초가 지났는지의 여부 반환
 
-  if (!previousTime) return true;
+  if (!previousTime) return true; // 최초 로그인 했을 때
 
-  const timeDiffInMillis = currentTime.getTime() - previousTime.getTime();
+  const timeDiffInMillis = currentTime.getTime() - previousTime?.getTime();
   return timeDiffInMillis >= 20000;
 }

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -12,7 +12,7 @@ export function getHeaders(isContentTypeJson = false) {
   };
 }
 
-export function goPageWithSelector(selector: Util.LogInState, router: any) {
+export function goPageWithSelector(selector: Model.LogInState, router: any) {
   const url = selector.goPage?.url;
 
   if (typeof url !== 'string') return;
@@ -50,4 +50,13 @@ export function formatTimeDifference(dateString: string) {
       value = Math.floor(diffMinutes / (60 * 24 * 30 * 12));
       return `${value}년 전`;
   }
+}
+
+export function checkCommentAddValidity(currentTime: Date, previousTime: Date | null) {
+  // 마지막 코멘트를 등록한 시점부터 20초가 지났는지의 여부 반환
+
+  if (!previousTime) return true;
+
+  const timeDiffInMillis = currentTime.getTime() - previousTime.getTime();
+  return timeDiffInMillis >= 20000;
 }

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -60,3 +60,15 @@ export function checkCommentAddValidity(currentTime: Date, previousTime: Date | 
   const timeDiffInMillis = currentTime.getTime() - previousTime?.getTime();
   return timeDiffInMillis >= 20000;
 }
+
+export function doSetActionWithNewValue(
+  prevState: any,
+  setState: React.Dispatch<React.SetStateAction<any>>,
+  index: number | null,
+  newValue: any,
+) {
+  const newState = index === null ? newValue : [...prevState];
+
+  if (index !== null) newState[index] = newValue;
+  setState(newState);
+}

--- a/apps/client/utils/common.ts
+++ b/apps/client/utils/common.ts
@@ -1,6 +1,6 @@
 import { LOGIN } from '@/constants/constant';
 
-export function getHeaders() {
+export function getHeaders(isContentTypeJson = false) {
   if (typeof sessionStorage === 'undefined') return;
   const sessionStorageDataString = sessionStorage.getItem(LOGIN.MONGBIT);
 
@@ -8,6 +8,7 @@ export function getHeaders() {
   const token = json ? json.recoil_logIn[LOGIN.TOKEN_NAME] : '';
   return {
     Authorization: token,
+    'Content-Type': isContentTypeJson ? 'application/json' : null,
   };
 }
 

--- a/apps/client/utils/logIn.ts
+++ b/apps/client/utils/logIn.ts
@@ -16,7 +16,6 @@ export function decodeToken(token: string | undefined): Util.DecodedToken {
   const currentTime = new Date();
 
   // const expirationTime = new Date(expiration * 1000 - 43140000);
-
   if (expirationTime < currentTime) {
     return {
       state: false,

--- a/apps/client/utils/logIn.ts
+++ b/apps/client/utils/logIn.ts
@@ -28,7 +28,7 @@ export function decodeToken(token: string | undefined): Util.DecodedToken {
   }
 }
 
-export function tokenValidate(logInState: Util.LogInState) {
+export function tokenValidate(logInState: Model.LogInState) {
   const token = logInState[LOGIN.TOKEN_NAME];
 
   // token이 없을 때 false 반환

--- a/apps/client/utils/mbtiTest.ts
+++ b/apps/client/utils/mbtiTest.ts
@@ -19,9 +19,9 @@ export function doSeeMoreMbtiTests({ fetchOption, data, page }: Util.doSeeMoreMb
   });
 }
 
-export function sortCommentByDate(data: Base.MbtiTestCommentData[]) {
+export function sortCommentByDate(data: Model.CommentData[]) {
   // 최신 순으로 정렬한 코멘트 데이터를 return 함
-  return [...data].sort((a: Base.MbtiTestCommentData, b: Base.MbtiTestCommentData) => {
+  return [...data].sort((a: Model.CommentData, b: Model.CommentData) => {
     const bValue = new Date(b.commentDate);
     const aValue = new Date(a.commentDate);
 

--- a/apps/client/utils/mbtiTest.ts
+++ b/apps/client/utils/mbtiTest.ts
@@ -1,5 +1,8 @@
+import { LOGIN, MESSAGE } from '@/constants/constant';
 import { fetchClient, updateLikeCount } from '@/services';
-import { getHeaders } from '@/utils/common';
+import { checkCommentAddValidity, getHeaders } from '@/utils/common';
+
+import { tokenValidate } from './logIn';
 
 export function updateLikeNumber(likeState: Util.LikeState, testId: Util.TestId, memberId: Util.MemberId) {
   const headers = getHeaders();
@@ -29,4 +32,22 @@ export function sortCommentByDate(data: Model.CommentData[]) {
     if (bValue < aValue) return -1;
     return 0;
   });
+}
+
+export function validationBeforeWriteComment(logInState: Model.LogInState, router: any) {
+  let result = true;
+  const isTokenValid = tokenValidate(logInState);
+  const prevCommentAddedDate = logInState[LOGIN.LAST_COMMENT_TIME] ? new Date(logInState.mbLastCommentTime) : null;
+  const canAddComment = checkCommentAddValidity(new Date(), prevCommentAddedDate);
+
+  if (!isTokenValid) {
+    router.push('/login');
+    return (result = false);
+  }
+  if (!canAddComment) {
+    alert(MESSAGE.COMMENT_TIME);
+    return (result = false);
+  }
+
+  return result;
 }

--- a/apps/client/utils/mbtiTest.ts
+++ b/apps/client/utils/mbtiTest.ts
@@ -20,8 +20,8 @@ export function doSeeMoreMbtiTests({ fetchOption, data, page }: Util.doSeeMoreMb
 }
 
 export function sortCommentByDate(data: Base.MbtiTestCommentData[]) {
-  // 코멘트를 최신 순으로 정렬
-  data.sort((a: Base.MbtiTestCommentData, b: Base.MbtiTestCommentData) => {
+  // 최신 순으로 정렬한 코멘트 데이터를 return 함
+  return [...data].sort((a: Base.MbtiTestCommentData, b: Base.MbtiTestCommentData) => {
     const bValue = new Date(b.commentDate);
     const aValue = new Date(a.commentDate);
 

--- a/apps/client/utils/types.d.ts
+++ b/apps/client/utils/types.d.ts
@@ -1,16 +1,4 @@
 declare namespace Util {
-  type LogInState = {
-    goPage?: {
-      url?: boolean | string;
-    };
-    key?: string;
-    mbRegisterDate?: string;
-    mbThumbnail?: string;
-    [key: string]: string | undefined;
-    mbUserID?: string;
-    mbUserName?: string;
-  };
-
   type DecodedToken = {
     state?: boolean;
     role?: string;

--- a/apps/client/utils/types.d.ts
+++ b/apps/client/utils/types.d.ts
@@ -20,7 +20,7 @@ declare namespace Util {
     };
     page: {
       page: number;
-      setPage: React.Dispatch<React.SetStateAction<number>>;
+      setPage: SetState.Number;
     };
   };
 


### PR DESCRIPTION
1. 사용되는 페이지
 - mbti 테스트 프리뷰 
 - mbti 테스트 결과지
 
2. 작업 목록
   - 댓글 추가
     - 엔터키로 댓글 추가할 수 있도록
     - value 없으면 댓글 추가할 수 없도록
     - 100 글자 제한
     - 댓글 연속 등록 제한(20초)
     - 댓글 추가 버튼 누르면 value 사라지도록
   - 댓글 수정
      - 본인이 작성한 코멘트만 수정 가능
      - 수정 state에 따라 버튼 텍스트 스위치(수정, 확인)
      - 수정 input 창 스타일링 및 100자 제한
      - 엔터키로 댓글 수정할 수 있도록
      - 수정 input 100자 제한 텍스트 생성
   - 댓글 삭제
     - USER: 본인이 작성한 코멘트만 삭제 가능     
     - ADMIN: 모든 코멘트 삭제 가능
     - 수정 state에 따라 버튼 텍스트 스위치(삭제, 취소)
   - 댓글 더 보기 기능 구현

3. 수정, 삭제 버튼 노출
  - 관리자 
     - 수정 : 본인이 작성한 댓글만 가능
     - 삭제: 모든 댓글 가능
  - 일반 유저
     - 수정, 삭제 : 본인이 작성한 댓글만 가능

4. 이슈
  - #31 