### PR TITLE
[client] services / fetchData, creatHeaders 함수 추가

### DIFF
--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -31,12 +31,10 @@ export const createHeaders = ({ contnetType, cacheControl }: createHeadersProrps
 };
 
 // params 추가
-export const fetchData = async <T>(url: string, { method, headers, body, params }: fetchDataProps) => {
+export const fetchData = async <T>(url: string, { body, ...fetchOptions }: fetchDataProps) => {
   const options = {
-    method: method,
-    headers: headers,
     body: JSON.stringify(body),
-    params: params,
+    ...fetchOptions,
   };
 
   const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL_PROD}${url}`, options);

--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -2,8 +2,20 @@ import { notFound } from 'next/navigation';
 
 import { LOGIN } from '@/constants/constant';
 
+interface createHeadersProrps {
+  contnetType?: string;
+  cacheControl?: string;
+}
+
+interface fetchDataProps {
+  method: string;
+  headers?: Headers;
+  body?: object;
+  params?: object;
+}
+
 // creatHeaders 추가
-export const creatHeaders = ({ contnetType, CacheControl }: { contnetType?: string; CacheControl?: string }) => {
+export const createHeaders = ({ contnetType, cacheControl }: createHeadersProrps) => {
   const headers = new Headers();
 
   if (typeof sessionStorage === 'undefined') return;
@@ -12,18 +24,11 @@ export const creatHeaders = ({ contnetType, CacheControl }: { contnetType?: stri
   const token = JSON.parse(loginData!).recoil_logIn[LOGIN.TOKEN_NAME];
 
   headers.append('Content-Type', contnetType || 'application/json');
-  headers.append('Cache-Control', CacheControl || 'public');
+  headers.append('Cache-Control', cacheControl || 'public');
   headers.append('Authorization', token);
 
   return headers;
 };
-
-interface fetchDataProps {
-  method: string;
-  headers?: Headers;
-  body?: object;
-  params?: object;
-}
 
 // params 추가
 export const fetchData = async <T>(url: string, { method, headers, body, params }: fetchDataProps) => {

--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -7,12 +7,12 @@ export const creatHeaders = ({ contnetType, CacheControl }: { contnetType?: stri
   const headers = new Headers();
 
   if (typeof sessionStorage === 'undefined') return;
-  const sessionStorageDataString = sessionStorage.getItem(LOGIN.MONGBIT);
-  const json = sessionStorageDataString ? JSON.parse(sessionStorageDataString) : null;
-  const token = json ? json.recoil_logIn[LOGIN.TOKEN_NAME] : '';
 
-  headers.append('Content-Type', contnetType ? contnetType : 'application/json');
-  headers.append('Cache-Control', CacheControl ? CacheControl : 'public');
+  const loginData = sessionStorage.getItem(LOGIN.MONGBIT);
+  const token = JSON.parse(loginData!).recoil_logIn[LOGIN.TOKEN_NAME];
+
+  headers.append('Content-Type', contnetType || 'application/json');
+  headers.append('Cache-Control', CacheControl || 'public');
   headers.append('Authorization', token);
 
   return headers;

--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -34,7 +34,7 @@ export const fetchData = async <T>(url: string, { method, headers, body, params 
     params: params,
   };
 
-  const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL_PROD}/api/v1${url}`, options);
+  const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL_PROD}${url}`, options);
 
   if (!response.ok) {
     switch (response.status) {

--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -21,7 +21,7 @@ export const createHeaders = ({ contnetType, cacheControl }: createHeadersProrps
   if (typeof sessionStorage === 'undefined') return;
 
   const loginData = sessionStorage.getItem(LOGIN.MONGBIT);
-  const token = JSON.parse(loginData!).recoil_logIn[LOGIN.TOKEN_NAME];
+  const token = loginData ? JSON.parse(loginData).recoil_logIn[LOGIN.TOKEN_NAME] : '';
 
   headers.append('Content-Type', contnetType || 'application/json');
   headers.append('Cache-Control', cacheControl || 'public');


### PR DESCRIPTION
### fetchData ###
  * 기존 함수 fetchClient () => fetchData() 
  * params 추가
  * respons data Type 설정
  * 파라미터 변경 : '(url: string, { method, headers, body, params })' => url 객체에서 분리
 
### 기존: getHeaders ###
 ```js
export function getHeaders(isContentTypeJson = false) {
  if (typeof sessionStorage === 'undefined') return;
  const sessionStorageDataString = sessionStorage.getItem(LOGIN.MONGBIT);

  const json = sessionStorageDataString ? JSON.parse(sessionStorageDataString) : null;
  const token = json ? json.recoil_logIn[LOGIN.TOKEN_NAME] : '';
  return {
    Authorization: token,
    'Content-Type': isContentTypeJson ? 'application/json' : null,
  };
}
```

* Authorization, Content-Type만 설정 가능
* Content-Type의 경우 boolean으로 구분

### 추가: creatHeaders ###
```js
export const creatHeaders = ({ contnetType, CacheControl }: { contnetType?: string; CacheControl?: string }) => {
  const headers = new Headers();

  if (typeof sessionStorage === 'undefined') return;

  const loginData = sessionStorage.getItem(LOGIN.MONGBIT);
  const token = JSON.parse(loginData!).recoil_logIn[LOGIN.TOKEN_NAME];

  headers.append('Content-Type', contnetType || 'application/json');
  headers.append('Cache-Control', CacheControl || 'public');
  headers.append('Authorization', token);

  return headers;
};
```
* Cache-Control, Content-Type 설정이 필요한 관계로 추가했습니다.
* fetchData에서 headers.append()를 바로 사용하도록 할까 했지만, 커스텀이 필요한 경우에만 사용 할 수 있도록 분리했습니다.
* Headers의 경우, node_modules에서 제공하고 있어, 따로 타입 추가 하지않고 사용 했습니다.

#47