### PR TITLE
[client] Feature/component 

### DIFF
--- a/apps/client/components/CommentList/CommentItem.tsx
+++ b/apps/client/components/CommentList/CommentItem.tsx
@@ -1,0 +1,100 @@
+import Image from 'next/image';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import * as B from '@/styles/base.style';
+import * as L from '@/styles/layout.style';
+import theme from '@/styles/theme';
+import { CommentData } from '@/types';
+import { formatTimeDifference } from '@/utils/common';
+
+import { COMMENT_MAX_LENGTH, IMAGE_ALT_TEXT } from '@/constants';
+
+interface Props {
+  comment: CommentData;
+  role?: string;
+  loginUserId?: string;
+  handleUpdateComment: (comment: CommentData, content: string) => void;
+  onClickDeleteButton: (id: string, memberId: string) => void;
+}
+
+const CommentButton = styled.button`
+  width: 25px;
+  background-color: transparent;
+  font-size: ${(props) => props.theme.font.size.s};
+  color: ${(props) => props.theme.colors.deepGray};
+`;
+
+const EditInput = styled.input`
+  width: 85%;
+  border: none;
+  outline: none;
+`;
+
+const CommentItem = ({ comment, role, loginUserId, handleUpdateComment, onClickDeleteButton }: Props) => {
+  const { thumbnailImage, username, commentDate, content, memberId, id } = comment;
+  const [value, setValue] = useState('');
+  const [isModifying, setIsModifying] = useState(false);
+
+  const onChangeInputValue = (event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value);
+
+  const onClickEditButton = () => setIsModifying(!isModifying);
+
+  const onClickSaveButton = () => {
+    handleUpdateComment(comment, value);
+    setIsModifying(!isModifying);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) onClickSaveButton();
+  };
+
+  return (
+    <B.Wrap_mediaquery padding="0.5rem 1.5rem" gap="0.8rem">
+      <Image
+        src={thumbnailImage}
+        alt={IMAGE_ALT_TEXT + '회원 이미지'}
+        width={40}
+        height={40}
+        style={{ borderRadius: '1rem' }}
+      />
+      <L.Flex width="100%" gap="0.5rem" $flexDirection="column" $alignItems="baseline">
+        <L.Flex width="100%" $justifyContent="space-between">
+          <B.Text>{`${username} · ${formatTimeDifference(commentDate)}`}</B.Text>
+          <L.Flex gap="0.3rem">
+            {loginUserId === memberId && (
+              <CommentButton onClick={isModifying ? () => onClickSaveButton() : onClickEditButton}>
+                {isModifying ? '저장' : '수정'}
+              </CommentButton>
+            )}
+            {(loginUserId === memberId || role === 'ROLE_ADMIN') && (
+              <CommentButton onClick={isModifying ? onClickEditButton : () => onClickDeleteButton(id, memberId)}>
+                {isModifying ? '취소' : '삭제'}
+              </CommentButton>
+            )}
+          </L.Flex>
+        </L.Flex>
+        {isModifying ? (
+          <L.Flex width="100%" $flexDirection="column">
+            <L.Flex width="100%" gap="0.5rem">
+              <EditInput
+                defaultValue={content}
+                type="Text"
+                maxLength={COMMENT_MAX_LENGTH}
+                onChange={onChangeInputValue}
+                onKeyDown={onKeyDown}
+              />
+              <B.Text fontSize={theme.font.size.xs}>
+                {value.length} / {COMMENT_MAX_LENGTH}
+              </B.Text>
+            </L.Flex>
+            <B.DividingLine margin="0" />
+          </L.Flex>
+        ) : (
+          <B.Text color={theme.colors.black}>{content}</B.Text>
+        )}
+      </L.Flex>
+    </B.Wrap_mediaquery>
+  );
+};
+export default CommentItem;

--- a/apps/client/components/CommentList/index.tsx
+++ b/apps/client/components/CommentList/index.tsx
@@ -199,7 +199,11 @@ const CommentList = ({ testId }: Props) => {
       </L.Flex>
 
       <L.Flex $flexDirection="column" margin="20px 0">
-        {commentData &&
+        {commentData.length === 0 ? (
+          <B.Text $lineHeight="70px" fontSize="17px">
+            첫 댓글을 남겨주세요! 🥳
+          </B.Text>
+        ) : (
           commentData.map((comment) => (
             <CommentItem
               key={comment.id}
@@ -209,7 +213,8 @@ const CommentList = ({ testId }: Props) => {
               handleUpdateComment={handleUpdateComment}
               onClickDeleteButton={onClickDeleteButton}
             />
-          ))}
+          ))
+        )}
 
         {hasNextPage && (
           <B.Button

--- a/apps/client/components/CommentList/index.tsx
+++ b/apps/client/components/CommentList/index.tsx
@@ -1,0 +1,231 @@
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+
+import { CommentImage, CommentSubmitImage } from '@/public/images/mbtiTest';
+import { atomloginState } from '@/recoil/atoms';
+import {
+  createHeaders,
+  deleteCommentAPI,
+  getCommentAPI,
+  getCommentCountAPI,
+  submitCommentAPI,
+  updateCommentAPI,
+} from '@/services';
+import * as B from '@/styles/base.style';
+import * as L from '@/styles/layout.style';
+import theme from '@/styles/theme';
+import { CommentData } from '@/types';
+import { decodeToken } from '@/utils/login';
+
+import CommentItem from './CommentItem';
+import IconButton from '../Buttons/IconButton';
+
+import { COMMENT_MAX_LENGTH, IMAGE_ALT_STRING, LOGIN } from '@/constants';
+
+interface Props {
+  testId: string;
+}
+
+const Input = styled.input`
+  width: 100%;
+  height: 2rem;
+  padding: 0 0.3rem;
+  background-color: transparent;
+  font-size: ${(props) => props.theme.font.size.s};
+  color: ${(props) => props.theme.colors.deepGray};
+  border-style: none;
+
+  &::placeholder {
+    font-size: ${(props) => props.theme.font.size.s};
+    color: ${(props) => props.theme.colors.deepGray};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const InputWrap = styled(L.Flex)<{ $isMaxLength?: boolean }>`
+  width: 100%;
+  height: 2.5rem;
+  justify-content: space-between;
+  background-color: ${(props) => props.theme.colors.lightGray};
+  padding: 8px;
+  border-radius: 0.4rem;
+
+  border-bottom: 2px solid ${(props) => (props.$isMaxLength ? 'red' : props.theme.colors.lightGray)};
+`;
+
+const CommentList = ({ testId }: Props) => {
+  const [value, setValue] = useState('');
+  const [page, setPage] = useState(0);
+  const [commentData, setCommentData] = useState<CommentData[]>([]);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [commentCount, setCommentCount] = useState(0);
+
+  const router = useRouter();
+  const userInfo = useRecoilValue(atomloginState);
+  const role = decodeToken(userInfo[LOGIN.TOKEN_NAME])?.role;
+  const loginUserId = userInfo[LOGIN.USER_MEMBER_ID];
+
+  const onChangeValue = (event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) onClickSubmitButton();
+  };
+
+  const getCommentCount = useCallback(async () => {
+    const res = await getCommentCountAPI(testId!);
+    if (res) {
+      setCommentCount(res);
+    }
+  }, [testId]);
+
+  const getComments = useCallback(async () => {
+    const res = await getCommentAPI(testId!, page);
+    if (res) {
+      setCommentData((prev) => [...prev, ...res.commentDTOList]);
+      setHasNextPage(res.hasNextPage);
+      setPage((prev) => prev + 1);
+    }
+  }, [testId, page]);
+
+  const fetchComments = useCallback(async () => {
+    const pages = Array.from({ length: page }, (_, i) => i);
+    const responses = await Promise.all(pages.map((p) => getCommentAPI(testId!, p)));
+
+    if (responses) {
+      setCommentData([]);
+
+      responses.forEach((res) => {
+        setCommentData((prev) => [...prev, ...res!.commentDTOList]);
+        setHasNextPage(res!.hasNextPage);
+      });
+
+      getCommentCount();
+    }
+  }, [testId, page, getCommentCount]);
+
+  const onClickSubmitButton = async () => {
+    if (value === '') return;
+    const headers = createHeaders();
+    const body = {
+      memberId: userInfo[LOGIN.USER_MEMBER_ID],
+      testId: testId,
+      content: value,
+    };
+
+    await submitCommentAPI(headers!, body);
+
+    setValue('');
+    fetchComments();
+  };
+
+  const handleUpdateComment = async (comment: CommentData, content: string) => {
+    const headers = createHeaders();
+
+    const body = {
+      id: comment.id,
+      memberId: comment.memberId,
+      testId: comment.testId,
+      commentDate: new Date(),
+      content: content,
+    };
+
+    await updateCommentAPI(headers!, body);
+    fetchComments();
+  };
+
+  const onClickDeleteButton = async (id: string, memberId: string) => {
+    const confirmResult = confirm('삭제하시겠습니까?');
+
+    if (!confirmResult) return;
+
+    const headers = createHeaders();
+    const body = {
+      id: id,
+      memberId: memberId,
+    };
+
+    await deleteCommentAPI(headers!, body);
+    fetchComments();
+  };
+
+  useEffect(() => {
+    getComments();
+    getCommentCount();
+  }, []);
+
+  return (
+    <>
+      <L.Flex $flexDirection="column" width="100%">
+        <L.Flex margin="0 0 0.5rem 0" width="100%" $justifyContent="space-between">
+          <L.Flex gap="0.3rem">
+            <B.ImageWrap width="1rem" height="1rem">
+              <Image src={CommentImage} alt={IMAGE_ALT_STRING + '코멘트 아이콘'} fill sizes="100%" />
+            </B.ImageWrap>
+            <B.Text>댓글 {commentCount}</B.Text>
+          </L.Flex>
+          <B.Text>
+            {value.length} / {COMMENT_MAX_LENGTH}
+          </B.Text>
+        </L.Flex>
+        {loginUserId ? (
+          <InputWrap $isMaxLength={value.length >= COMMENT_MAX_LENGTH}>
+            <Input
+              placeholder="나쁜말 하면 신고합니다 ㅇㅅㅇ"
+              value={value}
+              type="text"
+              maxLength={COMMENT_MAX_LENGTH}
+              onKeyDown={onKeyDown}
+              onChange={onChangeValue}
+            />
+            <IconButton
+              width="1.6rem"
+              height="1.6rem"
+              src={CommentSubmitImage}
+              isOn={true}
+              onClick={onClickSubmitButton}
+            />
+          </InputWrap>
+        ) : (
+          <B.Button onClick={() => router.push('/login')} $colorType="gray">
+            CLICK! 로그인 하고 댓글 달기!
+          </B.Button>
+        )}
+      </L.Flex>
+
+      <L.Flex $flexDirection="column" margin="20px 0">
+        {commentData &&
+          commentData.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              role={role}
+              loginUserId={loginUserId}
+              handleUpdateComment={handleUpdateComment}
+              onClickDeleteButton={onClickDeleteButton}
+            />
+          ))}
+
+        {hasNextPage && (
+          <B.Button
+            onClick={() => getComments()}
+            $colorType="gray"
+            $borderRadius="1rem"
+            width="7rem"
+            height="2rem"
+            fontSize={theme.font.size.s}
+            margin="20px 0"
+          >
+            더 보기
+          </B.Button>
+        )}
+      </L.Flex>
+    </>
+  );
+};
+export default CommentList;

--- a/apps/client/services/comment.ts
+++ b/apps/client/services/comment.ts
@@ -13,3 +13,5 @@ export const updateCommentAPI = (headers: Headers, body: object) =>
 
 export const deleteCommentAPI = (headers: Headers, body: object) =>
   fetchData(`/api/v1/test/comments`, 'DELETE', { headers, body });
+
+export const getCommentCountAPI = (testId: string) => fetchData<number>(`/api/v1/test/${testId}/comments/count`, 'GET');

--- a/apps/client/services/index.ts
+++ b/apps/client/services/index.ts
@@ -3,6 +3,7 @@ export * from './util';
 export * from './kakao';
 export * from './like';
 export * from './mbti';
+export * from './comment';
 
 // 기존
 export const fetchClient = async ({ url, method, headers, body }: Services.FetchClientProp) => {


### PR DESCRIPTION
### Comment Item
<img src="https://github.com/Mong-Bit/mongbit_fe_next_v2/assets/132863144/dfec30c4-29f2-4d70-9103-d90ebecb001e" alt="대체 텍스트" width="300" />
<img src="https://github.com/Mong-Bit/mongbit_fe_next_v2/assets/132863144/1ee7047e-9b00-415e-b136-dd40bf45198a" alt="대체 텍스트" width="300" />

* 관리자의경우 모든 댓글을 삭제 할 수 있습니다.
* 수정의 경우 해당 회원만 가능합니다.
* CommentItem 컴포넌트의 경우 부모로 받은 데이터를 표시하거나 함수를 실행하는 역할만 합니다.

---

### Comment List

<img src="https://github.com/Mong-Bit/mongbit_fe_next_v2/assets/132863144/33fd2581-1cd8-4fe5-bd7e-7ac3f6ce8803" alt="대체 텍스트" width="400" />

* 댓글의 생성,수정,삭제, 그리고 리스트 호출등을 담당 합니다.
* testId만을 prop으로 받아 해당 테스트에 관련된 댓글들을 관리합니다.

<img src="https://github.com/Mong-Bit/mongbit_fe_next_v2/assets/132863144/349b730b-897a-4887-83f2-e03470765d34" alt="대체 텍스트" width="300" />
<img src="https://github.com/Mong-Bit/mongbit_fe_next_v2/assets/132863144/ba842b1c-7bfa-4cb6-93d0-b34d441b05a4" alt="대체 텍스트" width="340" />

* 로그인이 되어있을 경우 댓글 작성이 바로 가능하며, 비로그인 회원의 경우 로그인페이지 이동 버튼이 노출됩니다.
* 댓글 입력창의 경우 컴포넌트 분리를 해야할까 고민을 좀 했습니다.
  * 재사용 가능성이 없음
  * 코드가 복잡하지 않음
* 컴포넌트를 분리한다고 하더라도 크게 장점이 보이지 않아 내부에서 처리했습니다.
* 근데..좀 긴거같은데 빼는게 좋을까요..?