### PR TITLE
fix: 로그인 했을 때 user 데이터가 recoil state로 추가되지 않는 문제 개선함

### DIFF
--- a/apps/client/containers/kakaoAuthHandle/index.tsx
+++ b/apps/client/containers/kakaoAuthHandle/index.tsx
@@ -39,10 +39,10 @@ export default function KakaoAuthHandle() {
         url: loginAtom.goPage ? loginAtom.goPage : '/',
       },
       [LOGIN.TOKEN_NAME]: response?.headers.get('Authorization'),
-      [LOGIN.USER_MEMBER_ID]: response?.memberId,
-      [LOGIN.USER_THUMBNAIL]: response?.thumbnail,
-      [LOGIN.USER_REGISTER_DATE]: response?.registDate,
-      [LOGIN.USER_NAME]: response?.username,
+      [LOGIN.USER_MEMBER_ID]: response?.data.memberId,
+      [LOGIN.USER_THUMBNAIL]: response?.data.thumbnail,
+      [LOGIN.USER_REGISTER_DATE]: response?.data.registDate,
+      [LOGIN.USER_NAME]: response?.data.username,
     });
   };
 

--- a/apps/client/services/util.ts
+++ b/apps/client/services/util.ts
@@ -65,8 +65,21 @@ export const fetchData = async <T>(url: string, method: Method, options?: Partia
 export const fetchLoginData = async <T>(url: string, method: Method, headers: Headers) => {
   const response = await fetch(`${process.env.NEXT_PUBLIC_BE_URL_PROD}${url}`, { method, headers });
 
+  if (!response.ok) {
+    switch (response.status) {
+      case 404:
+        return notFound();
+      case 401:
+        return;
+      default:
+        throw new Error('Failed to fetch data');
+    }
+  }
+
+  const data = await response.json();
+
   return {
-    data: response.json(),
+    data,
     headers: response.headers,
   } as T;
 };


### PR DESCRIPTION
**1. 기존 api 요청 함수를 업데이트된 /services api들로 업데이트 했습니다.**


**2. 로그인 요청 api 함수 생성**
로그인 요청 api의 응답 값에 headers를 가져와야 합니다.
기존 fetchData는 headers를 반환하지 않습니다.

- fetchData에 조건을 걸어서 다르게 return 함
- 로그인 fetch 함수를 하나 새로 만들어서 사용함

위의 두가지 방식 중 고민하다가 2번을 선택했습니다.




